### PR TITLE
#2 회원가입 구현

### DIFF
--- a/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
+++ b/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
@@ -1,7 +1,7 @@
 package com.example.againminninguser.domain.account.controller;
 
 import com.example.againminninguser.domain.account.domain.dto.request.LoginRequest;
-import com.example.againminninguser.domain.account.domain.dto.SignUp;
+import com.example.againminninguser.domain.account.domain.dto.SignUpDto;
 import com.example.againminninguser.domain.account.domain.dto.response.LoginResponse;
 import com.example.againminninguser.domain.account.domain.dto.response.TokenDto;
 import com.example.againminninguser.domain.account.service.AccountService;
@@ -21,8 +21,8 @@ public class AccountController {
 
     private final AccountService accountService;
 
-    @PostMapping("/sign-up")
-    public CustomResponseEntity<SignUp> signUp(@RequestBody SignUp signUp) {
+    @PostMapping("/")
+    public CustomResponseEntity<SignUpDto> signUp(@RequestBody SignUpDto signUp) {
         return new CustomResponseEntity<>(
                 Message.of(HttpStatus.OK, AccountContent.SIGN_UP_OK),
                 accountService.signUp(signUp)

--- a/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
+++ b/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
@@ -1,6 +1,7 @@
 package com.example.againminninguser.domain.account.controller;
 
 import com.example.againminninguser.domain.account.domain.dto.request.LoginRequest;
+import com.example.againminninguser.domain.account.domain.dto.SignUp;
 import com.example.againminninguser.domain.account.domain.dto.response.LoginResponse;
 import com.example.againminninguser.domain.account.domain.dto.response.TokenDto;
 import com.example.againminninguser.domain.account.service.AccountService;
@@ -19,6 +20,14 @@ import javax.websocket.server.PathParam;
 public class AccountController {
 
     private final AccountService accountService;
+
+    @PostMapping("/sign-up")
+    public CustomResponseEntity<SignUp> signUp(@RequestBody SignUp signUp) {
+        return new CustomResponseEntity<>(
+                Message.of(HttpStatus.OK, "회원가입 성공"),
+                accountService.signUp(signUp)
+        );
+    }
 
     @PostMapping("/login")
     public CustomResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {

--- a/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
+++ b/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
@@ -24,7 +24,7 @@ public class AccountController {
     @PostMapping("/sign-up")
     public CustomResponseEntity<SignUp> signUp(@RequestBody SignUp signUp) {
         return new CustomResponseEntity<>(
-                Message.of(HttpStatus.OK, "회원가입 성공"),
+                Message.of(HttpStatus.OK, AccountContent.SIGN_UP_OK),
                 accountService.signUp(signUp)
         );
     }

--- a/src/main/java/com/example/againminninguser/domain/account/domain/Account.java
+++ b/src/main/java/com/example/againminninguser/domain/account/domain/Account.java
@@ -43,4 +43,14 @@ public class Account {
     public void updateLastLogin() {
         this.lastLogin = LocalDateTime.now();
     }
+
+    public static Account of(String email, String password, String nickname) {
+        return Account.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .isAlarm(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/com/example/againminninguser/domain/account/domain/Account.java
+++ b/src/main/java/com/example/againminninguser/domain/account/domain/Account.java
@@ -19,13 +19,10 @@ public class Account {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /* Todo Add Validation */
     private String email;
 
-    /* Todo Add Validation */
     private String password;
 
-    /* Todo Add Validation */
     private String nickname;
 
     private String profile;

--- a/src/main/java/com/example/againminninguser/domain/account/domain/AccountRepository.java
+++ b/src/main/java/com/example/againminninguser/domain/account/domain/AccountRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/againminninguser/domain/account/domain/dto/SignUp.java
+++ b/src/main/java/com/example/againminninguser/domain/account/domain/dto/SignUp.java
@@ -1,0 +1,17 @@
+package com.example.againminninguser.domain.account.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SignUp {
+    private String email;
+    private String password;
+    private String nickname;
+
+    public static SignUp of(String email, String password, String nickname) {
+        return new SignUp(email, password, nickname);
+    }
+
+}

--- a/src/main/java/com/example/againminninguser/domain/account/domain/dto/SignUpDto.java
+++ b/src/main/java/com/example/againminninguser/domain/account/domain/dto/SignUpDto.java
@@ -5,13 +5,13 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class SignUp {
+public class SignUpDto {
     private String email;
     private String password;
     private String nickname;
 
-    public static SignUp of(String email, String password, String nickname) {
-        return new SignUp(email, password, nickname);
+    public static SignUpDto of(String email, String password, String nickname) {
+        return new SignUpDto(email, password, nickname);
     }
 
 }

--- a/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
+++ b/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
@@ -2,7 +2,7 @@ package com.example.againminninguser.domain.account.service;
 
 import com.example.againminninguser.domain.account.domain.Account;
 import com.example.againminninguser.domain.account.domain.AccountRepository;
-import com.example.againminninguser.domain.account.domain.dto.SignUp;
+import com.example.againminninguser.domain.account.domain.dto.SignUpDto;
 import com.example.againminninguser.domain.account.domain.dto.response.LoginResponse;
 import com.example.againminninguser.domain.account.domain.dto.response.TokenDto;
 import com.example.againminninguser.global.config.jwt.JwtProvider;
@@ -51,7 +51,7 @@ public class AccountService {
         }
     }
 
-    public SignUp signUp(SignUp signUp) {
+    public SignUpDto signUp(SignUpDto signUp) {
         checkDuplicatedEmail(signUp.getEmail());
         validateSignUpRequest(signUp);
         Account account = Account.of(
@@ -59,10 +59,10 @@ public class AccountService {
                 passwordEncoder.encode(signUp.getPassword()),
                 signUp.getNickname());
         Account savedAccount = accountRepository.save(account);
-        return SignUp.of(savedAccount.getEmail(), savedAccount.getPassword(), savedAccount.getNickname());
+        return SignUpDto.of(savedAccount.getEmail(), savedAccount.getPassword(), savedAccount.getNickname());
     }
 
-    private void validateSignUpRequest(SignUp signUp) {
+    private void validateSignUpRequest(SignUpDto signUp) {
         checkEmailFormat(signUp.getEmail());
         checkPasswordFormat(signUp.getPassword());
     }

--- a/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
+++ b/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
@@ -23,6 +23,9 @@ import static com.example.againminninguser.global.common.content.AccountContent.
 @Transactional
 public class AccountService {
 
+    private static final Pattern EMAIL_REGEX = Pattern.compile("^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$");
+    private static final Pattern PASSWORD_REGEX = Pattern.compile("^[a-zA-Z0-9]{8,20}");
+
     private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
@@ -65,8 +68,8 @@ public class AccountService {
     }
 
     private void checkEmailFormat(String email) {
-        String regex = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$";
-        boolean matches = Pattern.matches(regex, email);
+//        boolean matches = Pattern.matches(regex, email);
+        boolean matches = PASSWORD_REGEX.matcher(email).matches();
         if(!matches) {
             throw new BadRequestException(INVALID_EMAIL_FORMAT);
         }
@@ -74,8 +77,7 @@ public class AccountService {
     }
 
     private void checkPasswordFormat(String password) {
-        String regex = "^[a-zA-Z0-9]{8,20}";
-        boolean matches = Pattern.matches(regex, password);
+        boolean matches = EMAIL_REGEX.matcher(password).matches();
         if(!matches) {
             throw new BadRequestException(INVALID_PASSWORD_FORMAT);
         }

--- a/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
+++ b/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
@@ -6,6 +6,7 @@ import com.example.againminninguser.domain.account.domain.dto.SignUp;
 import com.example.againminninguser.domain.account.domain.dto.response.LoginResponse;
 import com.example.againminninguser.domain.account.domain.dto.response.TokenDto;
 import com.example.againminninguser.global.config.jwt.JwtProvider;
+import com.example.againminninguser.global.error.BadRequestException;
 import com.example.againminninguser.global.error.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -13,8 +14,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.regex.Pattern;
 
-import static com.example.againminninguser.global.common.content.AccountContent.USER_NOT_FOUND_BY_LOGIN;
+import static com.example.againminninguser.global.common.content.AccountContent.*;
 
 @Service
 @RequiredArgsConstructor
@@ -63,18 +65,27 @@ public class AccountService {
     }
 
     private void checkEmailFormat(String email) {
-        // if email is not access to format then throw exception
+        String regex = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$";
+        boolean matches = Pattern.matches(regex, email);
+        if(!matches) {
+            throw new BadRequestException(INVALID_EMAIL_FORMAT);
+        }
+
     }
 
     private void checkPasswordFormat(String password) {
-        // if password is not access to format then throw exception
+        String regex = "^[a-zA-Z0-9]{8,20}";
+        boolean matches = Pattern.matches(regex, password);
+        if(!matches) {
+            throw new BadRequestException(INVALID_PASSWORD_FORMAT);
+        }
 
     }
 
     private void checkDuplicatedEmail(String email) {
         boolean exists = accountRepository.existsByEmail(email);
         if(exists) {
-            // throw 중복 예외;
+            throw new BadRequestException(DUPLICATED_EMAIL);
         }
     }
 }

--- a/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
+++ b/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
@@ -2,6 +2,7 @@ package com.example.againminninguser.domain.account.service;
 
 import com.example.againminninguser.domain.account.domain.Account;
 import com.example.againminninguser.domain.account.domain.AccountRepository;
+import com.example.againminninguser.domain.account.domain.dto.SignUp;
 import com.example.againminninguser.domain.account.domain.dto.response.LoginResponse;
 import com.example.againminninguser.domain.account.domain.dto.response.TokenDto;
 import com.example.againminninguser.global.config.jwt.JwtProvider;
@@ -45,4 +46,35 @@ public class AccountService {
         }
     }
 
+    public SignUp signUp(SignUp signUp) {
+        checkDuplicatedEmail(signUp.getEmail());
+        validateSignUpRequest(signUp);
+        Account account = Account.of(
+                signUp.getEmail(),
+                passwordEncoder.encode(signUp.getPassword()),
+                signUp.getNickname());
+        Account savedAccount = accountRepository.save(account);
+        return SignUp.of(savedAccount.getEmail(), savedAccount.getPassword(), savedAccount.getNickname());
+    }
+
+    private void validateSignUpRequest(SignUp signUp) {
+        checkEmailFormat(signUp.getEmail());
+        checkPasswordFormat(signUp.getPassword());
+    }
+
+    private void checkEmailFormat(String email) {
+        // if email is not access to format then throw exception
+    }
+
+    private void checkPasswordFormat(String password) {
+        // if password is not access to format then throw exception
+
+    }
+
+    private void checkDuplicatedEmail(String email) {
+        boolean exists = accountRepository.existsByEmail(email);
+        if(exists) {
+            // throw 중복 예외;
+        }
+    }
 }

--- a/src/main/java/com/example/againminninguser/global/common/content/AccountContent.java
+++ b/src/main/java/com/example/againminninguser/global/common/content/AccountContent.java
@@ -2,6 +2,8 @@ package com.example.againminninguser.global.common.content;
 
 public class AccountContent {
 
+    private AccountContent() {}
+
     public static String USER_NOT_FOUND = "유저를 찾을 수 없습니다.";
     public static String USER_NOT_FOUND_BY_LOGIN = "아이디 혹은 비밀번호를 확인하세요.";
     public static String LOGIN_OK = "로그인 성공";
@@ -10,4 +12,8 @@ public class AccountContent {
     public static String MALFORMED_TOKEN = "토큰의 형식을 확인해주세요.";
     public static String EMPTY_TOKEN = "토큰이 비어있습니다.";
     public static String REFRESH_OK = "성공적으로 토큰을 재발행하였습니다.";
+
+    public static String INVALID_EMAIL_FORMAT = "이메일 형식을 확인하세요.";
+    public static String INVALID_PASSWORD_FORMAT = "비밀번호 형식을 확인하세요.";
+    public static String DUPLICATED_EMAIL = "이미 가입되어있는 이메일입니다.";
 }

--- a/src/main/java/com/example/againminninguser/global/common/content/AccountContent.java
+++ b/src/main/java/com/example/againminninguser/global/common/content/AccountContent.java
@@ -4,16 +4,17 @@ public class AccountContent {
 
     private AccountContent() {}
 
-    public static String USER_NOT_FOUND = "유저를 찾을 수 없습니다.";
-    public static String USER_NOT_FOUND_BY_LOGIN = "아이디 혹은 비밀번호를 확인하세요.";
-    public static String LOGIN_OK = "로그인 성공";
+    public static final String USER_NOT_FOUND = "유저를 찾을 수 없습니다.";
+    public static final String USER_NOT_FOUND_BY_LOGIN = "아이디 혹은 비밀번호를 확인하세요.";
+    public static final String LOGIN_OK = "로그인 성공";
 
-    public static String EXPIRED_TOKEN = "만료된 토큰입니다.";
-    public static String MALFORMED_TOKEN = "토큰의 형식을 확인해주세요.";
-    public static String EMPTY_TOKEN = "토큰이 비어있습니다.";
-    public static String REFRESH_OK = "성공적으로 토큰을 재발행하였습니다.";
+    public static final String EXPIRED_TOKEN = "만료된 토큰입니다.";
+    public static final String MALFORMED_TOKEN = "토큰의 형식을 확인해주세요.";
+    public static final String EMPTY_TOKEN = "토큰이 비어있습니다.";
+    public static final String REFRESH_OK = "성공적으로 토큰을 재발행하였습니다.";
 
-    public static String INVALID_EMAIL_FORMAT = "이메일 형식을 확인하세요.";
-    public static String INVALID_PASSWORD_FORMAT = "비밀번호 형식을 확인하세요.";
-    public static String DUPLICATED_EMAIL = "이미 가입되어있는 이메일입니다.";
+    public static final String SIGN_UP_OK = "회원가입이 성공하였습니다.";
+    public static final String INVALID_EMAIL_FORMAT = "이메일 형식을 확인하세요.";
+    public static final String INVALID_PASSWORD_FORMAT = "비밀번호 형식을 확인하세요.";
+    public static final String DUPLICATED_EMAIL = "이미 가입되어있는 이메일입니다.";
 }

--- a/src/main/java/com/example/againminninguser/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/againminninguser/global/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 토큰 기반 인증이므로 세션 X
                 .and()
                 .authorizeRequests()
-                .antMatchers("/api/v1/account/sign-up", "/api/v1/account/login", "/api/v1/account/refresh/**").permitAll()
+                .antMatchers("/api/v1/account/", "/api/v1/account/login", "/api/v1/account/refresh/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),

--- a/src/main/java/com/example/againminninguser/global/error/AccountExceptionHandler.java
+++ b/src/main/java/com/example/againminninguser/global/error/AccountExceptionHandler.java
@@ -24,4 +24,11 @@ public class AccountExceptionHandler {
         Message message = Message.of(e.getStatus(), e.getMessage());
         return new CustomResponseEntity<>(message);
     }
+
+    @ExceptionHandler(BadRequestException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public CustomResponseEntity<Message> handle(BadRequestException e){
+        Message message = Message.of(e.getStatus(), e.getMessage());
+        return new CustomResponseEntity<>(message);
+    }
 }

--- a/src/main/java/com/example/againminninguser/global/error/BadRequestException.java
+++ b/src/main/java/com/example/againminninguser/global/error/BadRequestException.java
@@ -1,0 +1,13 @@
+package com.example.againminninguser.global.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BadRequestException extends RuntimeException {
+    private final HttpStatus status;
+    public BadRequestException(String message){
+        super(message);
+        this.status = HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/test/java/com/example/againminninguser/domain/account/AccountServiceTest.java
+++ b/src/test/java/com/example/againminninguser/domain/account/AccountServiceTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("Account Service 테스트")
 public class AccountServiceTest {
 
     @InjectMocks

--- a/src/test/java/com/example/againminninguser/domain/account/AccountServiceTest.java
+++ b/src/test/java/com/example/againminninguser/domain/account/AccountServiceTest.java
@@ -1,0 +1,62 @@
+package com.example.againminninguser.domain.account;
+
+import com.example.againminninguser.domain.account.domain.AccountRepository;
+import com.example.againminninguser.domain.account.service.AccountService;
+import com.example.againminninguser.global.common.content.AccountContent;
+import com.example.againminninguser.global.error.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AccountServiceTest {
+
+    @InjectMocks
+    private AccountService accountService;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Test
+    @DisplayName("중복 이메일 검증 텍스트")
+    void duplicatedEmailTest() {
+        String email = "test@test.com";
+        given(accountRepository.existsByEmail(email)).willReturn(true);
+
+        String errorMessage =
+                assertThrows(BadRequestException.class,
+                () -> ReflectionTestUtils.invokeMethod(accountService, "checkDuplicatedEmail", email)).getMessage();
+        assertEquals(AccountContent.DUPLICATED_EMAIL, errorMessage);
+
+    }
+
+    @Test
+    @DisplayName("이메일 형식 검증 테스트")
+    void emailValidationTest() {
+        String email = "test";
+
+        String errorMessage =
+                assertThrows(BadRequestException.class,
+                () -> ReflectionTestUtils.invokeMethod(accountService, "checkEmailFormat", email)).getMessage();
+        assertEquals(AccountContent.INVALID_EMAIL_FORMAT, errorMessage);
+    }
+
+    @Test
+    @DisplayName("비밀번호 형식 검증 테스트")
+    void passwordValidationTest() {
+        String password = "1234567";
+
+        String errorMessage =
+                assertThrows(BadRequestException.class,
+                        () -> ReflectionTestUtils.invokeMethod(accountService, "checkPasswordFormat", password)).getMessage();
+        assertEquals(AccountContent.INVALID_PASSWORD_FORMAT, errorMessage);
+
+    }
+}

--- a/src/test/java/com/example/againminninguser/domain/account/api/AccountControllerTest.java
+++ b/src/test/java/com/example/againminninguser/domain/account/api/AccountControllerTest.java
@@ -1,0 +1,99 @@
+package com.example.againminninguser.domain.account.api;
+
+import com.example.againminninguser.domain.account.controller.AccountController;
+import com.example.againminninguser.domain.account.domain.dto.SignUp;
+import com.example.againminninguser.domain.account.service.AccountService;
+import com.example.againminninguser.global.common.AccountTemplate;
+import com.example.againminninguser.global.common.content.AccountContent;
+import com.example.againminninguser.global.config.jwt.JwtProvider;
+import com.example.againminninguser.global.error.BadRequestException;
+import com.example.againminninguser.global.error.CustomAuthenticationEntryPoint;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AccountController.class)
+@TestPropertySource(properties = { "${spring.jwt.key}=1234" })
+public class AccountControllerTest {
+
+    @MockBean
+    private AccountService accountService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+    @MockBean
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+
+    @Test
+    @DisplayName("잘못된 이메일 형식으로 회원가입 - 회원가입")
+    void signUpFailByBadEmail() throws Exception {
+        SignUp signUpInvalidEmail = AccountTemplate.signUpInvalidEmail;
+        given(accountService.signUp(any())).willThrow(new BadRequestException(AccountContent.INVALID_EMAIL_FORMAT));
+        String request = objectMapper.writeValueAsString(signUpInvalidEmail);
+
+        ResultActions perform = mockMvc.perform(post("/api/v1/account/sign-up")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(request));
+
+        perform
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(jsonPath("$.message.status").value(HttpStatus.BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message.msg").value(AccountContent.INVALID_EMAIL_FORMAT));
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호 형식으로 회원가입 - 회원가입")
+    void signUpFailByBadPassword() throws Exception {
+        SignUp signUpInvalidPassword = AccountTemplate.signUpInvalidPassword;
+        given(accountService.signUp(any())).willThrow(new BadRequestException(AccountContent.INVALID_PASSWORD_FORMAT));
+        String request = objectMapper.writeValueAsString(signUpInvalidPassword);
+
+        ResultActions perform = mockMvc.perform(post("/api/v1/account/sign-up")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(request));
+
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message.status").value(HttpStatus.BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message.msg").value(AccountContent.INVALID_PASSWORD_FORMAT));
+    }
+
+    @Test
+    @DisplayName("정상 회원가입 - 회원가입")
+    void signUpSuccess() throws Exception {
+        SignUp signUp = AccountTemplate.signUp;
+        given(accountService.signUp(any())).willReturn(signUp);
+        String request = objectMapper.writeValueAsString(signUp);
+
+        ResultActions perform = mockMvc.perform(post("/api/v1/account/sign-up")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(request));
+
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message.status").value(HttpStatus.OK.name()))
+                .andExpect(jsonPath("$.message.msg").value(AccountContent.SIGN_UP_OK))
+                .andExpect(jsonPath("$.data.email").value(signUp.getEmail()))
+                .andExpect(jsonPath("$.data.nickname").value(signUp.getNickname()));
+    }
+}

--- a/src/test/java/com/example/againminninguser/domain/account/api/AccountControllerTest.java
+++ b/src/test/java/com/example/againminninguser/domain/account/api/AccountControllerTest.java
@@ -1,7 +1,7 @@
 package com.example.againminninguser.domain.account.api;
 
 import com.example.againminninguser.domain.account.controller.AccountController;
-import com.example.againminninguser.domain.account.domain.dto.SignUp;
+import com.example.againminninguser.domain.account.domain.dto.SignUpDto;
 import com.example.againminninguser.domain.account.service.AccountService;
 import com.example.againminninguser.global.common.AccountTemplate;
 import com.example.againminninguser.global.common.content.AccountContent;
@@ -48,11 +48,11 @@ public class AccountControllerTest {
     @Test
     @DisplayName("잘못된 이메일 형식으로 회원가입 - 회원가입")
     void signUpFailByBadEmail() throws Exception {
-        SignUp signUpInvalidEmail = AccountTemplate.signUpInvalidEmail;
+        SignUpDto signUpInvalidEmail = AccountTemplate.signUpInvalidEmail;
         given(accountService.signUp(any())).willThrow(new BadRequestException(AccountContent.INVALID_EMAIL_FORMAT));
         String request = objectMapper.writeValueAsString(signUpInvalidEmail);
 
-        ResultActions perform = mockMvc.perform(post("/api/v1/account/sign-up")
+        ResultActions perform = mockMvc.perform(post("/api/v1/account/")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(request));
 
@@ -65,11 +65,11 @@ public class AccountControllerTest {
     @Test
     @DisplayName("잘못된 비밀번호 형식으로 회원가입 - 회원가입")
     void signUpFailByBadPassword() throws Exception {
-        SignUp signUpInvalidPassword = AccountTemplate.signUpInvalidPassword;
+        SignUpDto signUpInvalidPassword = AccountTemplate.signUpInvalidPassword;
         given(accountService.signUp(any())).willThrow(new BadRequestException(AccountContent.INVALID_PASSWORD_FORMAT));
         String request = objectMapper.writeValueAsString(signUpInvalidPassword);
 
-        ResultActions perform = mockMvc.perform(post("/api/v1/account/sign-up")
+        ResultActions perform = mockMvc.perform(post("/api/v1/account/")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(request));
 
@@ -82,11 +82,11 @@ public class AccountControllerTest {
     @Test
     @DisplayName("정상 회원가입 - 회원가입")
     void signUpSuccess() throws Exception {
-        SignUp signUp = AccountTemplate.signUp;
-        given(accountService.signUp(any())).willReturn(signUp);
-        String request = objectMapper.writeValueAsString(signUp);
+        SignUpDto signUpDto = AccountTemplate.signUp;
+        given(accountService.signUp(any())).willReturn(signUpDto);
+        String request = objectMapper.writeValueAsString(signUpDto);
 
-        ResultActions perform = mockMvc.perform(post("/api/v1/account/sign-up")
+        ResultActions perform = mockMvc.perform(post("/api/v1/account/")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(request));
 
@@ -94,7 +94,7 @@ public class AccountControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message.status").value(HttpStatus.OK.name()))
                 .andExpect(jsonPath("$.message.msg").value(AccountContent.SIGN_UP_OK))
-                .andExpect(jsonPath("$.data.email").value(signUp.getEmail()))
-                .andExpect(jsonPath("$.data.nickname").value(signUp.getNickname()));
+                .andExpect(jsonPath("$.data.email").value(signUpDto.getEmail()))
+                .andExpect(jsonPath("$.data.nickname").value(signUpDto.getNickname()));
     }
 }

--- a/src/test/java/com/example/againminninguser/domain/account/api/AccountControllerTest.java
+++ b/src/test/java/com/example/againminninguser/domain/account/api/AccountControllerTest.java
@@ -27,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(AccountController.class)
 @TestPropertySource(properties = { "${spring.jwt.key}=1234" })
+@DisplayName("Account Controller 테스트")
 public class AccountControllerTest {
 
     @MockBean

--- a/src/test/java/com/example/againminninguser/domain/account/dao/AccountRepositoryTest.java
+++ b/src/test/java/com/example/againminninguser/domain/account/dao/AccountRepositoryTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DisplayName("Account Repository Test")
+@DisplayName("Account Repository 테스트")
 public class AccountRepositoryTest {
 
     @Autowired
@@ -42,5 +42,26 @@ public class AccountRepositoryTest {
                 () -> assertEquals(account.getEmail(), accountByEmail.getEmail()),
                 () -> assertEquals(account.getNickname(), accountByEmail.getNickname())
         );
+    }
+
+    @Test
+    @DisplayName("이메일 존재 유뮤 조회 테스트 - 있는 경우")
+    void existAccountByEmailWhenDataIsIt() {
+        Account account = AccountTemplate.account;
+        accountRepository.save(account);
+
+        boolean exists = accountRepository.existsByEmail(account.getEmail());
+
+        assertTrue(exists);
+    }
+
+    @Test
+    @DisplayName("이메일 존재 유뮤 조회 테스트 - 없는 경우")
+    void existAccountByEmailWhenNoData() {
+        Account account = AccountTemplate.account;
+
+        boolean exists = accountRepository.existsByEmail(account.getEmail());
+
+        assertFalse(exists);
     }
 }

--- a/src/test/java/com/example/againminninguser/global/common/AccountTemplate.java
+++ b/src/test/java/com/example/againminninguser/global/common/AccountTemplate.java
@@ -1,6 +1,7 @@
 package com.example.againminninguser.global.common;
 
 import com.example.againminninguser.domain.account.domain.Account;
+import com.example.againminninguser.domain.account.domain.dto.SignUp;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -14,4 +15,13 @@ public class AccountTemplate {
                     .password(passwordEncoder.encode("12345678"))
                     .nickname("test")
                     .build();
+
+    public static final SignUp signUp =
+            SignUp.of("test@test.com", "12345678", "sol");
+
+    public static final SignUp signUpInvalidEmail =
+            SignUp.of("test", "12345678", "sol");
+
+    public static final SignUp signUpInvalidPassword =
+            SignUp.of("test@test.com", "1234567", "sol");
 }

--- a/src/test/java/com/example/againminninguser/global/common/AccountTemplate.java
+++ b/src/test/java/com/example/againminninguser/global/common/AccountTemplate.java
@@ -1,7 +1,7 @@
 package com.example.againminninguser.global.common;
 
 import com.example.againminninguser.domain.account.domain.Account;
-import com.example.againminninguser.domain.account.domain.dto.SignUp;
+import com.example.againminninguser.domain.account.domain.dto.SignUpDto;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -16,12 +16,12 @@ public class AccountTemplate {
                     .nickname("test")
                     .build();
 
-    public static final SignUp signUp =
-            SignUp.of("test@test.com", "12345678", "sol");
+    public static final SignUpDto signUp =
+            SignUpDto.of("test@test.com", "12345678", "sol");
 
-    public static final SignUp signUpInvalidEmail =
-            SignUp.of("test", "12345678", "sol");
+    public static final SignUpDto signUpInvalidEmail =
+            SignUpDto.of("test", "12345678", "sol");
 
-    public static final SignUp signUpInvalidPassword =
-            SignUp.of("test@test.com", "1234567", "sol");
+    public static final SignUpDto signUpInvalidPassword =
+            SignUpDto.of("test@test.com", "1234567", "sol");
 }

--- a/src/test/java/com/example/againminninguser/global/config/jwt/api/JwtProviderMvcTest.java
+++ b/src/test/java/com/example/againminninguser/global/config/jwt/api/JwtProviderMvcTest.java
@@ -19,7 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestPropertySource(properties = { "${spring.jwt.key}=1234" })
-@DisplayName("JwtProvider MVC(Validation) Test")
+@DisplayName("JwtProvider MVC(Validation) 테스트")
 public class JwtProviderMvcTest {
 
     @Autowired

--- a/src/test/java/com/example/againminninguser/global/config/jwt/service/JwtProviderTest.java
+++ b/src/test/java/com/example/againminninguser/global/config/jwt/service/JwtProviderTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @TestPropertySource(properties = { "${spring.jwt.key}=1234" })
 @ExtendWith({MockitoExtension.class})
-@DisplayName("JwtProvider Service Test")
+@DisplayName("JwtProvider Service 테스트")
 public class JwtProviderTest {
 
     @InjectMocks


### PR DESCRIPTION
회원가입 구현

- 회원가입 로직 구현
- 테스트 케이스 작성
  - API(Controller) 테스트
  - Service 테스트
  - Repository 테스트

### Request
`/api/v1/account/sign-up`
application/json
```json
{
    "email": "tete@test.com",
    "password": 12341234,
    "nickname": "sol"
}
```

### Response
```json
{
    "message": {
        "status": "OK",
        "msg": "회원가입 성공"
    },
    "data": {
        "email": "tete@test.com",
        "password": "{bcrypt}$2a$10$KSxX5...",
        "nickname": "sol"
    }
}
```
--- 
### 주절주절..

지난번 예외처리 관련해서 통합처리 고려해봤습니다.
아래 코드가 ExceptionHandler의 일부 코드입니다.
```java
 @ExceptionHandler(BadRequestException.class)
 @ResponseStatus(HttpStatus.BAD_REQUEST)
 public CustomResponseEntity<Message> handle(BadRequestException e){
     Message message = Message.of(e.getStatus(), e.getMessage());
     return new CustomResponseEntity<>(message);
 }
```
제가 커스텀 ResponseEntity를 만들어 사용해서 예외 응답을 처리할 때, 위 코드 어노테이션 보시면 `@ResponseStatus(HttpStatus.BAD_REQUEST)`를 통해 예외 Status를 설정해주고 있습니다.
그래서 만약 `RuntimeException`으로 처리해버리면 예외 Status를 다르게 설정할 수 없어서 도입을 고민했었습니다.
근데 이걸 `RuntimeException`으로 처리하는 것이 아니라 `HttpStatus`의 종류에 따라 처리하도록 하기로 했습니다.
따라서 이번에 보시면 `BadRequestException`의 핸들러 하나로 3개의 Exception을 처리하는 것을 보실 수 있습니다!.
물론 CuntomResponseEntity를 만들어 사용하지 않으면 아무런 상관이 없긴 합니다 ㅋㅋㅋ
주절주절..