### PR TITLE
#8 로그아웃 구현

### DIFF
--- a/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
+++ b/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
@@ -1,5 +1,6 @@
 package com.example.againminninguser.domain.account.controller;
 
+import com.example.againminninguser.domain.account.domain.Account;
 import com.example.againminninguser.domain.account.domain.dto.request.LoginRequest;
 import com.example.againminninguser.domain.account.domain.dto.SignUpDto;
 import com.example.againminninguser.domain.account.domain.dto.response.LoginResponse;
@@ -8,10 +9,12 @@ import com.example.againminninguser.domain.account.service.AccountService;
 import com.example.againminninguser.global.common.content.AccountContent;
 import com.example.againminninguser.global.common.response.CustomResponseEntity;
 import com.example.againminninguser.global.common.response.Message;
+import com.example.againminninguser.global.util.AuthAccount;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.websocket.server.PathParam;
 
 @RestController
@@ -20,6 +23,14 @@ import javax.websocket.server.PathParam;
 public class AccountController {
 
     private final AccountService accountService;
+
+    @GetMapping("/logout")
+    public CustomResponseEntity<Message> logout(@AuthAccount Account account, HttpServletRequest request) {
+        accountService.logout(account, request);
+        return new CustomResponseEntity<>(
+                Message.of(HttpStatus.OK, AccountContent.LOGOUT_OK)
+        );
+    }
 
     @PostMapping("/")
     public CustomResponseEntity<SignUpDto> signUp(@RequestBody SignUpDto signUp) {

--- a/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
+++ b/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
@@ -13,6 +13,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.regex.Pattern;
 
@@ -89,5 +90,9 @@ public class AccountService {
         if(exists) {
             throw new BadRequestException(DUPLICATED_EMAIL);
         }
+    }
+
+    public void logout(Account account, HttpServletRequest request) {
+        jwtProvider.logout(request, account.getEmail());
     }
 }

--- a/src/main/java/com/example/againminninguser/global/common/content/AccountContent.java
+++ b/src/main/java/com/example/againminninguser/global/common/content/AccountContent.java
@@ -2,6 +2,8 @@ package com.example.againminninguser.global.common.content;
 
 public class AccountContent {
 
+    public static final String LOGOUT_OK = "로그아웃 성공";
+
     private AccountContent() {}
 
     public static final String USER_NOT_FOUND = "유저를 찾을 수 없습니다.";

--- a/src/main/java/com/example/againminninguser/global/util/AuthAccount.java
+++ b/src/main/java/com/example/againminninguser/global/util/AuthAccount.java
@@ -1,0 +1,13 @@
+package com.example.againminninguser.global.util;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : account")
+public @interface AuthAccount { }


### PR DESCRIPTION
로그아웃 구현

로그아웃 BlackList 방식

1. AccessToken의 남은시간을 계산하여 Redis에 넣는다.
2. Redis에 존재하는 RefreshToken을 제거한다.
3. JwtProvider의 Validate에서 가장 먼저 Redis에 AccessToken이 존재하는지 확인하여 로그인 프로세스를 제어한다.
4. 로그아웃 진행 후 AccessToken 재발급 및 로그아웃 된 AccessToken으로 요청 시 만료된 토큰 예외 처리를 한다.

### Request

header
Authenication: bearer ey....

`/api/v1/account/logout (GET)`

### Response
```json
{
    "message": {
        "status": "OK",
        "msg": "로그아웃 성공"
    },
    "data": null
}
```