### PR TITLE
#12 공지사항 조회 API 설계 및 로직 구현

### DIFF
--- a/src/main/java/com/example/againminninguser/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/againminninguser/domain/notice/controller/NoticeController.java
@@ -1,0 +1,30 @@
+package com.example.againminninguser.domain.notice.controller;
+
+import com.example.againminninguser.domain.notice.domain.dto.NoticeDto;
+import com.example.againminninguser.domain.notice.service.NoticeService;
+import com.example.againminninguser.global.common.response.CustomResponseEntity;
+import com.example.againminninguser.global.common.response.Message;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.websocket.server.PathParam;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notice")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping("")
+    public CustomResponseEntity<List<NoticeDto>> getNotice(@PathParam("lastId") long lastId) {
+        return new CustomResponseEntity<> (
+                Message.of(HttpStatus.OK, "공지사항 조회 성공"),
+                noticeService.getNoticeList(lastId)
+        );
+    }
+}

--- a/src/main/java/com/example/againminninguser/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/againminninguser/domain/notice/controller/NoticeController.java
@@ -2,6 +2,7 @@ package com.example.againminninguser.domain.notice.controller;
 
 import com.example.againminninguser.domain.notice.domain.dto.NoticeDto;
 import com.example.againminninguser.domain.notice.service.NoticeService;
+import com.example.againminninguser.global.common.content.NoticeContent;
 import com.example.againminninguser.global.common.response.CustomResponseEntity;
 import com.example.againminninguser.global.common.response.Message;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,7 @@ public class NoticeController {
     @GetMapping("")
     public CustomResponseEntity<List<NoticeDto>> getNotice(@PathParam("lastId") long lastId) {
         return new CustomResponseEntity<> (
-                Message.of(HttpStatus.OK, "공지사항 조회 성공"),
+                Message.of(HttpStatus.OK, NoticeContent.NOTICE_OK),
                 noticeService.getNoticeList(lastId)
         );
     }

--- a/src/main/java/com/example/againminninguser/domain/notice/domain/Notice.java
+++ b/src/main/java/com/example/againminninguser/domain/notice/domain/Notice.java
@@ -1,0 +1,31 @@
+package com.example.againminninguser.domain.notice.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/example/againminninguser/domain/notice/domain/NoticeRepository.java
+++ b/src/main/java/com/example/againminninguser/domain/notice/domain/NoticeRepository.java
@@ -1,0 +1,11 @@
+package com.example.againminninguser.domain.notice.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    List<Notice> findTop5ByIdGreaterThanOrderById(Long lastId);
+}

--- a/src/main/java/com/example/againminninguser/domain/notice/domain/dto/NoticeDto.java
+++ b/src/main/java/com/example/againminninguser/domain/notice/domain/dto/NoticeDto.java
@@ -1,0 +1,28 @@
+package com.example.againminninguser.domain.notice.domain.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class NoticeDto {
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public NoticeDto (long id, String title, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/againminninguser/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/example/againminninguser/domain/notice/service/NoticeService.java
@@ -1,0 +1,33 @@
+package com.example.againminninguser.domain.notice.service;
+
+import com.example.againminninguser.domain.notice.domain.Notice;
+import com.example.againminninguser.domain.notice.domain.NoticeRepository;
+import com.example.againminninguser.domain.notice.domain.dto.NoticeDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    @Transactional(readOnly = true)
+    public List<NoticeDto> getNoticeList(long offset) {
+        List<Notice> noticeList = noticeRepository.findTop5ByIdGreaterThanOrderById(offset);
+        return noticeList.stream().map(notice ->
+                        NoticeDto.builder()
+                                .id(notice.getId())
+                                .title(notice.getTitle())
+                                .content(notice.getContent())
+                                .createdAt(notice.getCreatedAt())
+                                .updatedAt(notice.getUpdatedAt()).build())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/example/againminninguser/global/common/content/NoticeContent.java
+++ b/src/main/java/com/example/againminninguser/global/common/content/NoticeContent.java
@@ -1,0 +1,8 @@
+package com.example.againminninguser.global.common.content;
+
+public class NoticeContent {
+
+    private NoticeContent() {}
+
+    public static final String NOTICE_OK = "공지사항 조회 성공";
+}

--- a/src/test/java/com/example/againminninguser/domain/notice/dao/NoticeRepositoryTest.java
+++ b/src/test/java/com/example/againminninguser/domain/notice/dao/NoticeRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.example.againminninguser.domain.notice.dao;
+
+import com.example.againminninguser.domain.notice.domain.Notice;
+import com.example.againminninguser.domain.notice.domain.NoticeRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Notice Repository 테스트")
+public class NoticeRepositoryTest {
+
+    @Autowired
+    private NoticeRepository noticeRepository;
+
+    @BeforeAll
+    void setNoticeData() {
+        List<Notice> noticeList = new ArrayList<>();
+        for(int i = 1; i <= 6; i++) {
+            Notice notice = Notice.builder()
+                    .id((long) i)
+                    .title(i + "번 공지")
+                    .content(i + "번 공지내용")
+                    .createdAt(LocalDateTime.now().minusDays(1))
+                    .updatedAt(LocalDateTime.now()).build();
+            noticeList.add(notice);
+        }
+        noticeRepository.saveAll(noticeList);
+    }
+
+    @Test
+    @DisplayName("findTop5ByIdGreaterThanOrderById 테스트 - Limit 테스트")
+    void getNoticeList() {
+        List<Notice> noticeList = noticeRepository.findTop5ByIdGreaterThanOrderById((long) 2);
+        Assertions.assertEquals(4, noticeList.size());
+    }
+}


### PR DESCRIPTION
공지사항 조회 API 설계 및 로직 구현

limit은 5로 설정
아래 응답 예시는 공지사항이 6개 등록되어있는 경우

### Request
`/api/v1/notice?lastId=3 (GET)`

### Response
```json
{
    "message": {
        "status": "OK",
        "msg": "공지사항 조회 성공"
    },
    "data": [
        {
            "id": 4
            "title": "4번",
            "content": "4번 공지사항",
            "createdAt": null,
            "updatedAt": null
        },
        {
            "id": 5,
            "title": "5번",
            "content": "5번 공지사항",
            "createdAt": null,
            "updatedAt": null
        }, 
        {
            "id": 6,
            "title": "6번",
            "content": "6번 공지사항",
            "createdAt": null,
            "updatedAt": null
        }
    ]
}
```