### PR TITLE
#13 명언 조회 및 오늘의 명언 업데이트 구현

### DIFF
--- a/src/main/java/com/example/againminninguser/domain/account/domain/Account.java
+++ b/src/main/java/com/example/againminninguser/domain/account/domain/Account.java
@@ -29,6 +29,8 @@ public class Account {
 
     private boolean isAlarm;
 
+    private boolean isQuote;
+
     private String fcmToken;
 
     private LocalDateTime createdAt;
@@ -54,5 +56,9 @@ public class Account {
     public void updateProfile(String url) {
         this.profile = url;
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public void changeIsQuoteOfStatus() {
+        this.isQuote = !this.isQuote;
     }
 }

--- a/src/main/java/com/example/againminninguser/domain/quote/controller/QuoteController.java
+++ b/src/main/java/com/example/againminninguser/domain/quote/controller/QuoteController.java
@@ -1,0 +1,33 @@
+package com.example.againminninguser.domain.quote.controller;
+
+import com.example.againminninguser.domain.quote.domain.dto.QuoteDto;
+import com.example.againminninguser.domain.quote.service.QuoteService;
+import com.example.againminninguser.global.common.content.QuoteContent;
+import com.example.againminninguser.global.common.response.CustomResponseEntity;
+import com.example.againminninguser.global.common.response.Message;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/quote")
+public class QuoteController {
+
+    private final QuoteService quoteService;
+
+    @GetMapping("")
+    public CustomResponseEntity<QuoteDto> getQuoteOfToday() {
+        return new CustomResponseEntity<>(
+                Message.of(HttpStatus.OK, QuoteContent.QUOTE_OF_TODAY_OK),
+                quoteService.getQuoteOfToday()
+        );
+    }
+
+    @GetMapping("/update")
+    public void updateQuoteOfToday() {
+        quoteService.updateQuoteOfToday();
+    }
+}

--- a/src/main/java/com/example/againminninguser/domain/quote/controller/QuoteController.java
+++ b/src/main/java/com/example/againminninguser/domain/quote/controller/QuoteController.java
@@ -27,7 +27,14 @@ public class QuoteController {
     }
 
     @GetMapping("/update")
-    public void updateQuoteOfToday() {
-        quoteService.updateQuoteOfToday();
+    public CustomResponseEntity<Message> updateQuoteOfToday() {
+        boolean result = quoteService.updateQuoteOfToday();
+        return result
+                ? new CustomResponseEntity<>(
+                    Message.of(HttpStatus.OK, QuoteContent.QUOTE_UPDATE_OK)
+                )
+                : new CustomResponseEntity<>(
+                    Message.of(HttpStatus.INTERNAL_SERVER_ERROR, QuoteContent.QUOTE_UPDATE_ERROR)
+                );
     }
 }

--- a/src/main/java/com/example/againminninguser/domain/quote/domain/Quote.java
+++ b/src/main/java/com/example/againminninguser/domain/quote/domain/Quote.java
@@ -1,0 +1,25 @@
+package com.example.againminninguser.domain.quote.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Quote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String author;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+}

--- a/src/main/java/com/example/againminninguser/domain/quote/domain/QuoteRepository.java
+++ b/src/main/java/com/example/againminninguser/domain/quote/domain/QuoteRepository.java
@@ -1,0 +1,13 @@
+package com.example.againminninguser.domain.quote.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuoteRepository extends JpaRepository<Quote, Long> {
+    @Query("select que.id from Quote que")
+    List<Long> findIdList();
+}

--- a/src/main/java/com/example/againminninguser/domain/quote/domain/dto/QuoteDto.java
+++ b/src/main/java/com/example/againminninguser/domain/quote/domain/dto/QuoteDto.java
@@ -1,0 +1,11 @@
+package com.example.againminninguser.domain.quote.domain.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class QuoteDto {
+    private String author;
+    private String content;
+}

--- a/src/main/java/com/example/againminninguser/domain/quote/service/QuoteService.java
+++ b/src/main/java/com/example/againminninguser/domain/quote/service/QuoteService.java
@@ -30,13 +30,14 @@ public class QuoteService {
         return QuoteDto.builder().author(author).content(content).build();
     }
 
-    public void updateQuoteOfToday() {
+    public boolean updateQuoteOfToday() {
         long randomQuoteId = getRandomQuoteId();
         Quote quote = quoteRepository.findById(randomQuoteId).get();
         redisTemplate.delete("Quote-author");
         redisTemplate.delete("Quote-content");
         redisTemplate.opsForValue().set("Quote-author", quote.getAuthor());
         redisTemplate.opsForValue().set("Quote-content", quote.getContent());
+        return true;
     }
 
     private long getRandomQuoteId() {

--- a/src/main/java/com/example/againminninguser/domain/quote/service/QuoteService.java
+++ b/src/main/java/com/example/againminninguser/domain/quote/service/QuoteService.java
@@ -1,0 +1,47 @@
+package com.example.againminninguser.domain.quote.service;
+
+import com.example.againminninguser.domain.quote.domain.Quote;
+import com.example.againminninguser.domain.quote.domain.QuoteRepository;
+import com.example.againminninguser.domain.quote.domain.dto.QuoteDto;
+import com.example.againminninguser.global.common.content.QuoteContent;
+import com.example.againminninguser.global.error.ServerErrorException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class QuoteService {
+
+    private final QuoteRepository quoteRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final Random random;
+
+    public QuoteDto getQuoteOfToday() {
+        String author = redisTemplate.opsForValue().get("Quote-author");
+        String content = redisTemplate.opsForValue().get("Quote-content");
+        if(Objects.isNull(author) || Objects.isNull(content)) {
+            throw new ServerErrorException(QuoteContent.QUOTE_IS_EMPTY);
+        }
+        return QuoteDto.builder().author(author).content(content).build();
+    }
+
+    public void updateQuoteOfToday() {
+        long randomQuoteId = getRandomQuoteId();
+        Quote quote = quoteRepository.findById(randomQuoteId).get();
+        redisTemplate.delete("Quote-author");
+        redisTemplate.delete("Quote-content");
+        redisTemplate.opsForValue().set("Quote-author", quote.getAuthor());
+        redisTemplate.opsForValue().set("Quote-content", quote.getContent());
+    }
+
+    private long getRandomQuoteId() {
+        List<Long> idList = quoteRepository.findIdList();
+        int randomIndex = random.nextInt(idList.size());
+        return idList.get(randomIndex);
+    }
+}

--- a/src/main/java/com/example/againminninguser/global/common/content/QuoteContent.java
+++ b/src/main/java/com/example/againminninguser/global/common/content/QuoteContent.java
@@ -4,9 +4,11 @@ import lombok.Data;
 
 @Data
 public class QuoteContent {
-
     private QuoteContent() {}
 
     public static final String QUOTE_OF_TODAY_OK = "오늘의 명언 조회를 성공하였습니다.";
     public static final String QUOTE_IS_EMPTY = "오늘의 명언이 비어있습니다.";
+    public static final String QUOTE_UPDATE_OK = "오늘의 명언 업데이트를 성공하였습니다.";
+
+    public static final String QUOTE_UPDATE_ERROR = "오늘의 명언 업데이틀르 실패하였습니다.";
 }

--- a/src/main/java/com/example/againminninguser/global/common/content/QuoteContent.java
+++ b/src/main/java/com/example/againminninguser/global/common/content/QuoteContent.java
@@ -1,0 +1,12 @@
+package com.example.againminninguser.global.common.content;
+
+import lombok.Data;
+
+@Data
+public class QuoteContent {
+
+    private QuoteContent() {}
+
+    public static final String QUOTE_OF_TODAY_OK = "오늘의 명언 조회를 성공하였습니다.";
+    public static final String QUOTE_IS_EMPTY = "오늘의 명언이 비어있습니다.";
+}

--- a/src/main/java/com/example/againminninguser/global/common/content/QuoteContent.java
+++ b/src/main/java/com/example/againminninguser/global/common/content/QuoteContent.java
@@ -10,5 +10,5 @@ public class QuoteContent {
     public static final String QUOTE_IS_EMPTY = "오늘의 명언이 비어있습니다.";
     public static final String QUOTE_UPDATE_OK = "오늘의 명언 업데이트를 성공하였습니다.";
 
-    public static final String QUOTE_UPDATE_ERROR = "오늘의 명언 업데이틀르 실패하였습니다.";
+    public static final String QUOTE_UPDATE_ERROR = "오늘의 명언 업데이트를 실패하였습니다.";
 }

--- a/src/main/java/com/example/againminninguser/global/config/AppConfig.java
+++ b/src/main/java/com/example/againminninguser/global/config/AppConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.Random;
+
 @Configuration
 public class AppConfig {
 
@@ -13,4 +15,8 @@ public class AppConfig {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
+    @Bean
+    public Random random() {
+        return new Random();
+    }
 }

--- a/src/main/java/com/example/againminninguser/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/againminninguser/global/config/SecurityConfig.java
@@ -29,7 +29,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 토큰 기반 인증이므로 세션 X
                 .and()
                 .authorizeRequests()
-                .antMatchers("/api/v1/account/", "/api/v1/account/login", "/api/v1/account/refresh/**").permitAll()
+                .antMatchers(
+                        "/api/v1/account/", "/api/v1/account/login", "/api/v1/account/refresh/**",
+                        "/api/v1/quote/update").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),

--- a/src/main/java/com/example/againminninguser/global/error/ServerErrorException.java
+++ b/src/main/java/com/example/againminninguser/global/error/ServerErrorException.java
@@ -1,0 +1,13 @@
+package com.example.againminninguser.global.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ServerErrorException extends RuntimeException {
+    private final HttpStatus status;
+    public ServerErrorException(String message){
+        super(message);
+        this.status = HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/src/test/java/com/example/againminninguser/domain/account/dao/AccountTest.java
+++ b/src/test/java/com/example/againminninguser/domain/account/dao/AccountTest.java
@@ -1,0 +1,37 @@
+package com.example.againminninguser.domain.account.dao;
+
+import com.example.againminninguser.domain.account.domain.Account;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AccountTest {
+
+
+    @Test
+    @DisplayName("updateProfile 테스트")
+    void updateProfileTest() {
+        LocalDateTime minusHours = LocalDateTime.now().minusHours(1);
+        String mockUrl = "https://velog.io/@solchan";
+        Account account = Account.builder().profile("").updatedAt(minusHours).build();
+        account.updateProfile(mockUrl);
+        assertAll(
+                () -> assertEquals(mockUrl, account.getProfile()),
+                () -> assertNotEquals(minusHours, account.getUpdatedAt())
+        );
+    }
+
+    @Test
+    @DisplayName("changeIsQuoteOfStatus 테스트")
+    void changeIsQuoteOfStatusTest() {
+        Account account = Account.builder().isQuote(false).build();
+        account.changeIsQuoteOfStatus();
+        assertTrue(account.isQuote());
+    }
+}

--- a/src/test/java/com/example/againminninguser/domain/quote/dao/QuoteRepositoryTest.java
+++ b/src/test/java/com/example/againminninguser/domain/quote/dao/QuoteRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.example.againminninguser.domain.quote.dao;
+
+import com.example.againminninguser.domain.quote.domain.Quote;
+import com.example.againminninguser.domain.quote.domain.QuoteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Quote Repository 테스트")
+public class QuoteRepositoryTest {
+
+    @Autowired
+    private QuoteRepository quoteRepository;
+
+    @Test
+    void findIdListTest() {
+        Quote build = Quote.builder().author("솔찬").content("놀자").build();
+        Quote build1 = Quote.builder().author("솔찬2").content("자자").build();
+        Quote build2 = Quote.builder().author("솔찬3").content("쉬자").build();
+        quoteRepository.saveAll(List.of(build, build1, build2));
+
+        List<Long> idList = quoteRepository.findIdList();
+
+        assertEquals(3, idList.size());
+    }
+
+}

--- a/src/test/java/com/example/againminninguser/global/common/AccountTemplate.java
+++ b/src/test/java/com/example/againminninguser/global/common/AccountTemplate.java
@@ -17,11 +17,11 @@ public class AccountTemplate {
                     .build();
 
     public static final SignUpDto signUp =
-            SignUpDto.of("test@test.com", "12345678", "sol");
+            new SignUpDto("test@test.com", "12345678", "sol");
 
     public static final SignUpDto signUpInvalidEmail =
-            SignUpDto.of("test", "12345678", "sol");
+            new SignUpDto("test", "12345678", "sol");
 
     public static final SignUpDto signUpInvalidPassword =
-            SignUpDto.of("test@test.com", "1234567", "sol");
+            new SignUpDto("test@test.com", "1234567", "sol");
 }


### PR DESCRIPTION
명언 조회 및 오늘의 명언 업데이트 구현

- 명언 조회 및 오늘의 명언 업테이트 API 설계 및 서비스 로직 작성
  - 오늘의 명언은 Redis에 저장
  - 매일 특정 시간에 업테이트 API를 호출하여 오늘의 명언을 업데이트
  - Reids 관련 테스트케이스는 #9 를 진행하면서 작성예정
- Account 비즈니스 로직 테스트 케이스 작성

## 명언 조회
**Request**
`/api/v1/quote (GET)`

**Response**
```json
{
    "message": {
        "status": "OK",
        "msg": "오늘의 명언 조회 성공"
    },
    "data": {
        "author": "솔찬",
        "content": "놀자"
    }
}
```

## 오늘의 명언 업데이트
**Request**
`/api/v1/quote/update (GET)`
jwt 필요 x

**Response**
(STATUS 200)
```json
{
    "message": {
        "status": "OK",
        "msg": "오늘의 명언 업데이트를 성공하였습니다."
    },
    "data": null
}
```
실패
(STATUS 500)
```json
{
    "message": {
        "status": "INTERNAL_SERVER_ERROR",
        "msg": "오늘의 명언 업데이트를 실패하였습니다."
    },
    "data": null
}
```
