### PR TITLE
#14 비밀번호 재설정 구현

### DIFF
--- a/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
+++ b/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
@@ -3,6 +3,7 @@ package com.example.againminninguser.domain.account.controller;
 import com.example.againminninguser.domain.account.domain.Account;
 import com.example.againminninguser.domain.account.domain.dto.request.LoginRequest;
 import com.example.againminninguser.domain.account.domain.dto.SignUpDto;
+import com.example.againminninguser.domain.account.domain.dto.request.PasswordRequest;
 import com.example.againminninguser.domain.account.domain.dto.request.ProfileRequest;
 import com.example.againminninguser.domain.account.domain.dto.response.LoginResponse;
 import com.example.againminninguser.domain.account.domain.dto.response.ProfileResponse;
@@ -25,6 +26,14 @@ import javax.websocket.server.PathParam;
 public class AccountController {
 
     private final AccountService accountService;
+
+    @PatchMapping("/password")
+    public CustomResponseEntity<Message> updatePassword(@AuthAccount Account account, @RequestBody PasswordRequest passwordRequest) {
+        accountService.updatePassword(account, passwordRequest);
+        return new CustomResponseEntity<>(
+                Message.of(HttpStatus.OK, AccountContent.PASSWORD_UPDATE_OK)
+        );
+    }
 
     @PatchMapping("/profile")
     public CustomResponseEntity<ProfileResponse> updateProfile(@AuthAccount Account account, ProfileRequest profile) {

--- a/src/main/java/com/example/againminninguser/domain/account/domain/Account.java
+++ b/src/main/java/com/example/againminninguser/domain/account/domain/Account.java
@@ -55,4 +55,8 @@ public class Account {
         this.profile = url;
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/com/example/againminninguser/domain/account/domain/dto/request/PasswordRequest.java
+++ b/src/main/java/com/example/againminninguser/domain/account/domain/dto/request/PasswordRequest.java
@@ -1,0 +1,9 @@
+package com.example.againminninguser.domain.account.domain.dto.request;
+
+import lombok.Data;
+
+@Data
+public class PasswordRequest {
+    private String newPassword;
+    private String newPasswordConfirm;
+}

--- a/src/main/java/com/example/againminninguser/domain/account/domain/dto/request/PasswordRequest.java
+++ b/src/main/java/com/example/againminninguser/domain/account/domain/dto/request/PasswordRequest.java
@@ -1,8 +1,10 @@
 package com.example.againminninguser.domain.account.domain.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class PasswordRequest {
     private String newPassword;
     private String newPasswordConfirm;

--- a/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
+++ b/src/main/java/com/example/againminninguser/domain/account/service/AccountService.java
@@ -3,6 +3,7 @@ package com.example.againminninguser.domain.account.service;
 import com.example.againminninguser.domain.account.domain.Account;
 import com.example.againminninguser.domain.account.domain.AccountRepository;
 import com.example.againminninguser.domain.account.domain.dto.SignUpDto;
+import com.example.againminninguser.domain.account.domain.dto.request.PasswordRequest;
 import com.example.againminninguser.domain.account.domain.dto.request.ProfileRequest;
 import com.example.againminninguser.domain.account.domain.dto.response.LoginResponse;
 import com.example.againminninguser.domain.account.domain.dto.response.ProfileResponse;
@@ -105,5 +106,20 @@ public class AccountService {
         account.updateProfile(originalFilename);
         accountRepository.save(account);
         return ProfileResponse.from(originalFilename);
+    }
+
+    public void updatePassword(Account account, PasswordRequest passwordRequest) {
+        this.checkPasswordConfirm(passwordRequest.getNewPassword(), passwordRequest.getNewPasswordConfirm());
+        this.checkPasswordFormat(passwordRequest.getNewPassword());
+        String newPassword = passwordEncoder.encode(passwordRequest.getNewPassword());
+        account.updatePassword(newPassword);
+        accountRepository.save(account);
+    }
+
+    private void checkPasswordConfirm(String password, String passwordConfirm) {
+        boolean equals = password.equals(passwordConfirm);
+        if(!equals) {
+            throw new BadRequestException(PASSWORD_CONFIRM_INVALID);
+        }
     }
 }

--- a/src/main/java/com/example/againminninguser/global/common/content/AccountContent.java
+++ b/src/main/java/com/example/againminninguser/global/common/content/AccountContent.java
@@ -21,4 +21,7 @@ public class AccountContent {
     public static final String DUPLICATED_EMAIL = "이미 가입되어있는 이메일입니다.";
 
     public static final String PROFILE_UPDATE_OK = "프로필 정보 수정 성공";
+
+    public static final String PASSWORD_UPDATE_OK = "비밀번호를 성공적으로 수정 성공";
+    public static final String PASSWORD_CONFIRM_INVALID = "비밀번호가 서로 다릅니다.";
 }

--- a/src/test/java/com/example/againminninguser/domain/account/AccountServiceTest.java
+++ b/src/test/java/com/example/againminninguser/domain/account/AccountServiceTest.java
@@ -60,4 +60,17 @@ public class AccountServiceTest {
         assertEquals(AccountContent.INVALID_PASSWORD_FORMAT, errorMessage);
 
     }
+
+    @Test
+    @DisplayName("비밀번호 확인 검증 테스트")
+    void passwordConfirmTest() {
+        String password = "12345678";
+        String passwordConfirm = "87654321";
+
+        String errorMessage = assertThrows(BadRequestException.class,
+                () -> ReflectionTestUtils.invokeMethod(
+                        accountService, "checkPasswordConfirm", password, passwordConfirm)
+        ).getMessage();
+        assertEquals(AccountContent.PASSWORD_CONFIRM_INVALID, errorMessage);
+    }
 }

--- a/src/test/java/com/example/againminninguser/domain/account/api/AccountControllerTest.java
+++ b/src/test/java/com/example/againminninguser/domain/account/api/AccountControllerTest.java
@@ -2,9 +2,11 @@ package com.example.againminninguser.domain.account.api;
 
 import com.example.againminninguser.domain.account.controller.AccountController;
 import com.example.againminninguser.domain.account.domain.dto.SignUpDto;
+import com.example.againminninguser.domain.account.domain.dto.request.PasswordRequest;
 import com.example.againminninguser.domain.account.service.AccountService;
 import com.example.againminninguser.global.common.AccountTemplate;
 import com.example.againminninguser.global.common.content.AccountContent;
+import com.example.againminninguser.global.config.account.TestAccount;
 import com.example.againminninguser.global.config.jwt.JwtProvider;
 import com.example.againminninguser.global.error.BadRequestException;
 import com.example.againminninguser.global.error.CustomAuthenticationEntryPoint;
@@ -22,7 +24,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AccountController.class)
@@ -96,5 +98,22 @@ public class AccountControllerTest {
                 .andExpect(jsonPath("$.message.msg").value(AccountContent.SIGN_UP_OK))
                 .andExpect(jsonPath("$.data.email").value(signUpDto.getEmail()))
                 .andExpect(jsonPath("$.data.nickname").value(signUpDto.getNickname()));
+    }
+
+    @Test
+    @TestAccount
+    @DisplayName("서로 다른 비밀번호 - 비밀번호 변경")
+    void updatePasswordFailByNotEqual() throws Exception {
+        PasswordRequest badPasswordRequest = AccountTemplate.badPasswordRequest;
+        String request = objectMapper.writeValueAsString(badPasswordRequest);
+        willThrow(new BadRequestException(AccountContent.PASSWORD_CONFIRM_INVALID))
+                .given(accountService).updatePassword(any(), any());
+        ResultActions perform = mockMvc.perform(patch("/api/v1/account/password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(request));
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message.status").value(HttpStatus.BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message.msg").value(AccountContent.PASSWORD_CONFIRM_INVALID));
     }
 }

--- a/src/test/java/com/example/againminninguser/global/common/AccountTemplate.java
+++ b/src/test/java/com/example/againminninguser/global/common/AccountTemplate.java
@@ -2,6 +2,7 @@ package com.example.againminninguser.global.common;
 
 import com.example.againminninguser.domain.account.domain.Account;
 import com.example.againminninguser.domain.account.domain.dto.SignUpDto;
+import com.example.againminninguser.domain.account.domain.dto.request.PasswordRequest;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -24,4 +25,7 @@ public class AccountTemplate {
 
     public static final SignUpDto signUpInvalidPassword =
             new SignUpDto("test@test.com", "1234567", "sol");
+
+    public static final PasswordRequest badPasswordRequest =
+            new PasswordRequest("12345678", "87654321");
 }

--- a/src/test/java/com/example/againminninguser/global/common/AccountTemplate.java
+++ b/src/test/java/com/example/againminninguser/global/common/AccountTemplate.java
@@ -17,11 +17,11 @@ public class AccountTemplate {
                     .build();
 
     public static final SignUpDto signUp =
-            SignUpDto.of("test@test.com", "12345678", "sol");
+            new SignUpDto("test@test.com", "12345678", "sol");
 
     public static final SignUpDto signUpInvalidEmail =
-            SignUpDto.of("test", "12345678", "sol");
+            new SignUpDto("test", "12345678", "sol");
 
     public static final SignUpDto signUpInvalidPassword =
-            SignUpDto.of("test@test.com", "1234567", "sol");
+            new SignUpDto("test@test.com", "1234567", "sol");
 }

--- a/src/test/java/com/example/againminninguser/global/config/account/TestAccount.java
+++ b/src/test/java/com/example/againminninguser/global/config/account/TestAccount.java
@@ -1,0 +1,10 @@
+package com.example.againminninguser.global.config.account;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithUserDetailsSecurityContextFactory.class)
+public @interface TestAccount { }

--- a/src/test/java/com/example/againminninguser/global/config/account/WithUserDetailsSecurityContextFactory.java
+++ b/src/test/java/com/example/againminninguser/global/config/account/WithUserDetailsSecurityContextFactory.java
@@ -1,0 +1,20 @@
+package com.example.againminninguser.global.config.account;
+
+import com.example.againminninguser.domain.account.domain.dto.UserAccount;
+import com.example.againminninguser.global.common.AccountTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithUserDetailsSecurityContextFactory implements WithSecurityContextFactory<TestAccount> {
+    @Override
+    public SecurityContext createSecurityContext(TestAccount annotation) {
+        UserDetails userAccount = new UserAccount(AccountTemplate.account);
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(userAccount, "", userAccount.getAuthorities());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(token);
+        return context;
+    }
+}


### PR DESCRIPTION
비밀번호 재설정 구현

### Request
`/api/v1/account/password (PATCH)`

### Response
```json
{
    "message": {
        "status": "OK",
        "msg": "비밀번호를 성공적으로 수정 성공"
    },
    "data": null
}
```

서로 다른 경우
```json
{
    "message": {
        "status": "BAD_REQUEST",
        "msg": "비밀번호가 서로 다릅니다."
    },
    "data": null
}
```

형식에 맞지 않는 경우
```json
{
    "message": {
        "status": "BAD_REQUEST",
        "msg": "비밀번호 형식을 확인하세요."
    },
    "data": null
}
```