### PR TITLE
비밀번호 찾기 로직 구현(이메일 발송 및 인증번호 인증 구현)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'com.h2database:h2'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
+++ b/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
@@ -13,6 +13,7 @@ import com.example.againminninguser.global.common.content.AccountContent;
 import com.example.againminninguser.global.common.response.CustomResponseEntity;
 import com.example.againminninguser.global.common.response.Message;
 import com.example.againminninguser.global.util.AuthAccount;
+import com.example.againminninguser.global.util.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -20,12 +21,31 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.websocket.server.PathParam;
 
+import static com.example.againminninguser.global.common.content.MailContent.*;
+
 @RestController
 @RequestMapping("/api/v1/account")
 @RequiredArgsConstructor
 public class AccountController {
 
     private final AccountService accountService;
+    private final MailService mailService;
+
+    @GetMapping("/confirm")
+    public CustomResponseEntity<TokenDto> confirmAuthKey(@PathParam("email") String email, @PathParam("authKey") String authKey) {
+        return new CustomResponseEntity<>(
+                Message.of(HttpStatus.OK, AUTH_KEY_OK),
+                mailService.confirmAuthKey(email, authKey)
+        );
+    }
+
+    @GetMapping("/mail")
+    public CustomResponseEntity<Message> sendMail(@PathParam("email") String email) {
+        mailService.sendAuthMail(email);
+        return new CustomResponseEntity<>(
+                Message.of(HttpStatus.OK, EMAIL_SEND_OK)
+        );
+    }
 
     @PatchMapping("/password")
     public CustomResponseEntity<Message> updatePassword(@AuthAccount Account account, @RequestBody PasswordRequest passwordRequest) {

--- a/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
+++ b/src/main/java/com/example/againminninguser/domain/account/controller/AccountController.java
@@ -13,7 +13,7 @@ import com.example.againminninguser.global.common.content.AccountContent;
 import com.example.againminninguser.global.common.response.CustomResponseEntity;
 import com.example.againminninguser.global.common.response.Message;
 import com.example.againminninguser.global.util.AuthAccount;
-import com.example.againminninguser.global.util.MailService;
+import com.example.againminninguser.global.util.MailUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -29,19 +29,19 @@ import static com.example.againminninguser.global.common.content.MailContent.*;
 public class AccountController {
 
     private final AccountService accountService;
-    private final MailService mailService;
+    private final MailUtil mailUtil;
 
     @GetMapping("/confirm")
     public CustomResponseEntity<TokenDto> confirmAuthKey(@PathParam("email") String email, @PathParam("authKey") String authKey) {
         return new CustomResponseEntity<>(
                 Message.of(HttpStatus.OK, AUTH_KEY_OK),
-                mailService.confirmAuthKey(email, authKey)
+                mailUtil.confirmAuthKey(email, authKey)
         );
     }
 
     @GetMapping("/mail")
     public CustomResponseEntity<Message> sendMail(@PathParam("email") String email) {
-        mailService.sendAuthMail(email);
+        mailUtil.sendAuthMail(email);
         return new CustomResponseEntity<>(
                 Message.of(HttpStatus.OK, EMAIL_SEND_OK)
         );

--- a/src/main/java/com/example/againminninguser/global/common/content/MailContent.java
+++ b/src/main/java/com/example/againminninguser/global/common/content/MailContent.java
@@ -1,0 +1,11 @@
+package com.example.againminninguser.global.common.content;
+
+public class MailContent {
+    private MailContent(){};
+
+    public static final String SEND_MAIL_FAIL = "메일 발송에 실패하였습니다.";
+    public static final String EXPIRED_AUTH_KEY = "인증번호가 만료되었습니다.";
+    public static final String AUTH_KEY_NOT_EQUAL = "인증번호가 일치하지 않습니다.";
+    public static final String AUTH_KEY_OK = "인증번호 인증에 성공하였습니다.";
+    public static final String EMAIL_SEND_OK = "이메일을 발송하였습니다.";
+}

--- a/src/main/java/com/example/againminninguser/global/config/MailConfiguration.java
+++ b/src/main/java/com/example/againminninguser/global/config/MailConfiguration.java
@@ -1,0 +1,23 @@
+package com.example.againminninguser.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+@Configuration
+@RequiredArgsConstructor
+public class MailConfiguration {
+
+    private final JavaMailSender javaMailSender;
+
+    @Bean
+    public MimeMessageHelper getMimeMessageHelper() throws MessagingException {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        return new MimeMessageHelper(mimeMessage, true, "UTF-8");
+    }
+}

--- a/src/main/java/com/example/againminninguser/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/againminninguser/global/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers(
                         "/api/v1/account/", "/api/v1/account/login", "/api/v1/account/refresh/**",
-                        "/api/v1/quote/update").permitAll()
+                        "/api/v1/quote/update", "/api/v1/account/mail", "/api/v1/account/confirm").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),

--- a/src/main/java/com/example/againminninguser/global/util/MailService.java
+++ b/src/main/java/com/example/againminninguser/global/util/MailService.java
@@ -1,0 +1,69 @@
+package com.example.againminninguser.global.util;
+
+import com.example.againminninguser.domain.account.domain.dto.response.TokenDto;
+import com.example.againminninguser.global.config.jwt.JwtProvider;
+import com.example.againminninguser.global.error.BadRequestException;
+import com.example.againminninguser.global.error.ServerErrorException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+
+import static com.example.againminninguser.global.common.content.MailContent.*;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+    private final JavaMailSender mailSender;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final Random random;
+    private final MimeMessageHelper messageHelper;
+    private final JwtProvider jwtProvider;
+
+    private String getAuthCode() {
+        String authKey = "";
+        for(int i = 0; i < 6; i++) {
+            int num = random.nextInt(9);
+            authKey += String.valueOf(num);
+        }
+        return authKey;
+    }
+
+    public void sendAuthMail(String email) {
+        String authKey = this.getAuthCode();
+        String text = "<h1>[이메일 인증]</h1>" +
+                "<p>아래의 인증번호를 입력하여 인증을 진행하세요.</p>"
+                + "<p>인증번호는 3분간 유효합니다.</p>"
+                + "인증번호 = " + authKey;
+        try {
+            messageHelper.setSubject("비밀번호 변경 재설정 인증메일");
+            messageHelper.setText(text, true);
+            messageHelper.setTo(email);
+            mailSender.send(messageHelper.getMimeMessage());
+        } catch (MessagingException  e) {
+            throw new ServerErrorException(SEND_MAIL_FAIL);
+        }
+        redisTemplate.opsForValue().set(email, authKey, Duration.ofMillis( 3 * 60 * 1000L ));
+    }
+
+    public TokenDto confirmAuthKey(String email, String authKey) {
+        String authKeyInRedis = redisTemplate.opsForValue().get(email);
+        if(Objects.isNull(authKeyInRedis)) {
+            throw new BadRequestException(EXPIRED_AUTH_KEY);
+        }
+        boolean result = authKey.equals(authKeyInRedis);
+        if(!result) {
+            throw new BadRequestException(AUTH_KEY_NOT_EQUAL);
+        }
+        redisTemplate.delete(email);
+        String tempToken = jwtProvider.createToken(email, List.of(""), 3 * 60 * 1000L);
+        return TokenDto.of(tempToken, null);
+    }
+}

--- a/src/main/java/com/example/againminninguser/global/util/MailUtil.java
+++ b/src/main/java/com/example/againminninguser/global/util/MailUtil.java
@@ -20,7 +20,7 @@ import static com.example.againminninguser.global.common.content.MailContent.*;
 
 @Service
 @RequiredArgsConstructor
-public class MailService {
+public class MailUtil {
     private final JavaMailSender mailSender;
     private final RedisTemplate<String, String> redisTemplate;
     private final Random random;
@@ -50,11 +50,11 @@ public class MailService {
         } catch (MessagingException  e) {
             throw new ServerErrorException(SEND_MAIL_FAIL);
         }
-        redisTemplate.opsForValue().set(email, authKey, Duration.ofMillis( 3 * 60 * 1000L ));
+        redisTemplate.opsForValue().set("AuthKey_" + email, authKey, Duration.ofMillis( 3 * 60 * 1000L ));
     }
 
     public TokenDto confirmAuthKey(String email, String authKey) {
-        String authKeyInRedis = redisTemplate.opsForValue().get(email);
+        String authKeyInRedis = redisTemplate.opsForValue().get("AuthKey_" + email);
         if(Objects.isNull(authKeyInRedis)) {
             throw new BadRequestException(EXPIRED_AUTH_KEY);
         }
@@ -62,7 +62,7 @@ public class MailService {
         if(!result) {
             throw new BadRequestException(AUTH_KEY_NOT_EQUAL);
         }
-        redisTemplate.delete(email);
+        redisTemplate.delete("AuthKey_" + email);
         String tempToken = jwtProvider.createToken(email, List.of(""), 3 * 60 * 1000L);
         return TokenDto.of(tempToken, null);
     }


### PR DESCRIPTION
비밀번호 찾기 로직 구현(이메일 발송 및 인증번호 인증 구현)

- 인증메일 발송 구현
  - 인증키는 Redis에 email: authKey로 저장 expiredTime은 3분 지정
- 발송한 인증번호 인증 구현
  - Redis에 저장된 인증번호와 비교하여 인증 진행
  - 인증이 성공한 경우 3분의 임시 토큰을 발행하여 응답
  - 임시 토큰을 발급받으면 이를 통해 비밀번호 변경 API를 통해 비밀번호를 변경
-  메일 발송 및 인증 테스트 케이스는 많은 로직이 외부 라이브러리를 통해 진행되기 때문에 추후 #9 를 진행하면서 Redis관련 된 테스트 케이스 작성 예정

## 인증메일 발송

### Request
`/api/v1/account/mail?email=dev.sol0427@gmail.com (GET)`
jwt X
### Response
```json
{
    "message": {
        "status": "OK",
        "msg": "이메일을 발송하였습니다."
    },
    "data": null
}
```

### 메일 
![image](https://user-images.githubusercontent.com/64524916/152509462-882be33d-7a2e-49ce-ab72-c3a2b5ad4e06.png)


## 인증번호 인증

### Request
`/api/v1/account/confirm?authKey=701652&email=dev.sol0427@gmail.com (GET)`
jwt X
### Response
```json
{
    "message": {
        "status": "OK",
        "msg": "인증번호 인증에 성공하였습니다."
    },
    "data": {
        "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkZXYuc29sMDQyN0BnbWFpbC5jb20iLCJyb2xlcyI6WyIiXSwiaWF0IjoxNjQzOTY4MzkwLCJleHAiOjE2NDM5Njg1NzB9.-YBsCZaxE4Oo8enGeXJwUM8DIQnLPhSa346ANFyFYmc",
        "refreshToken": null
    }
}
```