### PR TITLE
#9 RedisTemplate 관련 테스트 케이스 작성

### DIFF
--- a/src/test/java/com/example/againminninguser/domain/account/api/AccountControllerTest.java
+++ b/src/test/java/com/example/againminninguser/domain/account/api/AccountControllerTest.java
@@ -10,6 +10,7 @@ import com.example.againminninguser.global.config.account.TestAccount;
 import com.example.againminninguser.global.config.jwt.JwtProvider;
 import com.example.againminninguser.global.error.BadRequestException;
 import com.example.againminninguser.global.error.CustomAuthenticationEntryPoint;
+import com.example.againminninguser.global.util.MailUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,8 @@ public class AccountControllerTest {
     private JwtProvider jwtProvider;
     @MockBean
     private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    @MockBean
+    private MailUtil mailUtil;
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/example/againminninguser/global/common/redis/RedisTemplateTest.java
+++ b/src/test/java/com/example/againminninguser/global/common/redis/RedisTemplateTest.java
@@ -1,0 +1,66 @@
+package com.example.againminninguser.global.common.redis;
+
+import com.example.againminninguser.domain.quote.domain.Quote;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("RedisTemplate 테스트")
+public class RedisTemplateTest {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @AfterAll
+    void deleteAll() {
+        try {
+            Set<String> keys = redisTemplate.keys("*");
+            redisTemplate.delete(Objects.requireNonNull(keys));
+        } catch (NullPointerException e) {
+            System.out.println("Redis가 비어있습니다.");
+        }
+    }
+
+    @Test
+    @DisplayName("Set 테스트")
+    void createTest() {
+        //given
+        Quote quote = Quote.builder().id(1L).content("꿀 잠을 자요").author("솔찬").build();
+        final String AUTHOR_KEY = "Quote-Author";
+        final String CONTENT_KEY = "Quote-Content";
+
+        // when
+        redisTemplate.opsForValue().set(AUTHOR_KEY, quote.getAuthor(), Duration.ofMillis(5000L));
+        redisTemplate.opsForValue().set(CONTENT_KEY, quote.getContent());
+        String author = redisTemplate.opsForValue().get(AUTHOR_KEY);
+        String content = redisTemplate.opsForValue().get(CONTENT_KEY);
+
+        // then
+        assertThat(author).isEqualTo("솔찬");
+        assertThat(content).isEqualTo("꿀 잠을 자요");
+    }
+
+    @Test
+    @DisplayName("TTL 테스트")
+    void expiredTest() throws InterruptedException {
+        // given
+        final String ACCESS_TOKEN = "eydasdasd...";
+
+        // when
+        redisTemplate.opsForValue().set(ACCESS_TOKEN, "BlackList", Duration.ofMillis(500L));
+        Thread.sleep(1000L);
+        String accessToken = redisTemplate.opsForValue().get(ACCESS_TOKEN);
+
+        // then
+        assertThat(accessToken).isNull();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,6 +5,11 @@ spring:
   jpa:
     database: h2
     generate-ddl: off
+  redis:
+    host: localhost
+    port: 63790
+  jwt:
+    key: 1231
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:testdb;
@@ -13,3 +18,14 @@ spring:
     initialization-mode: always
 #    schema: classpath:schema-h2.sql
 #    data: classpath:data-h2.sql
+  mail:
+    username: dev.pinetree@gmail.com
+    password:
+    host: smtp.gmail.com
+    port: 587
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+          auth: true


### PR DESCRIPTION
RedisTemplate 관련 테스트 케이스 작성

RedisRepository를 만들어 사용하려 했으나 다음의 이유로 기존 RedisTemplate 사용
- 직렬화 과정에서 객체에 따라 설정이 필요한데 현재 사용 용도에서는 사용 필요성이 없다고 판단.
- TTL 설정이 객체에 대해 설정하는 방식이며 동적으로 변경 가능하도록 설정 또한 간단하지 않음
- 최종적으로 현재 Redis를 간단한 스트링 저장 및 TTL 기능 사용 용도로만 사용하기 때문에 기존 스타일을 유지하기로 결정

RedisTemplate로 단순 set, get, ttl 기능만 사용하므로 이에대한 테스트 케이스 작성